### PR TITLE
Bump version to 1.2.4 and patch command-line bug

### DIFF
--- a/recipe/fix_command.patch
+++ b/recipe/fix_command.patch
@@ -1,0 +1,42 @@
+diff --git a/setup.py b/setup.py
+index abfaa3f..e909c20 100755
+--- a/setup.py
++++ b/setup.py
+@@ -66,5 +66,5 @@ setup(
+     packages=find_packages(exclude=EXCLUDE_FROM_PACKAGES),
+     install_requires=install_requires,
+     classifiers=classifiers,
+-    entry_points={'console_scripts': ['slugify=slugify.slugify:main']},
++    entry_points={'console_scripts': ['slugify=slugify.cli:main']},
+ )
+diff --git a/slugify/cli.py b/slugify/cli.py
+new file mode 100644
+index 0000000..0fee3de
+--- /dev/null
++++ b/slugify/cli.py
+@@ -0,0 +1,9 @@
++import sys
++from slugify import slugify
++
++def main(): # pragma: no cover
++    if len(sys.argv) < 2:
++        print("Usage %s TEXT TO SLUGIFY" % sys.argv[0])
++    else:
++        text = ' '.join(sys.argv[1:])
++        print(slugify(text))
+diff --git a/slugify/slugify.py b/slugify/slugify.py
+index af0c609..6ad766e 100644
+--- a/slugify/slugify.py
++++ b/slugify/slugify.py
+@@ -155,11 +155,3 @@ def slugify(text, entities=True, decimal=True, hexadecimal=True, max_length=0, w
+         text = text.replace(DEFAULT_SEPARATOR, separator)
+ 
+     return text
+-
+-
+-def main(): # pragma: no cover
+-    if len(sys.argv) < 2:
+-        print("Usage %s TEXT TO SLUGIFY" % sys.argv[0])
+-    else:
+-        text = ' '.join(sys.argv[1:])
+-        print(slugify(text))

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ about:
   home: https://github.com/un33k/python-slugify
   license: MIT
   license_family: MIT
-  license_file: LICENSE
+  # license_file: LICENSE There is no license in python-slugify
   summary: 'A Python Slugify application that handles Unicode'
   dev_url: https://github.com/un33k/python-slugify
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "python-slugify" %}
-{% set version = "1.2.1" %}
-{% set sha256 = "501182ec738cc8b743ae5c76c183f4427187ef016257f062b3fa594f60916e34" %}
+{% set version = "1.2.4" %}
+{% set sha256 = "57a385df7a1c6dbd15f7666eaff0ff29d3f60363b228b1197c5308ed3ba5f824" %}
 
 package:
   name: {{ name|lower }}
@@ -10,12 +10,14 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+      - fix_command.patch
 
 build:
   number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
-    - slugify = slugify.slugify:main
+    - slugify = slugify.cli:main
 
 requirements:
   build:
@@ -30,6 +32,10 @@ test:
   imports:
     - slugify
 
+  commands:
+    - slugify --help
+
+
 about:
   home: https://github.com/un33k/python-slugify
   license: MIT
@@ -41,3 +47,4 @@ about:
 extra:
   recipe-maintainers:
     - proinsias
+    - sodre


### PR DESCRIPTION
- Patch code so the cli interface works (ref un33k/python-slugify#41)
  - Bump version to 1.2.4
  - Add sodre as a co-maintainer