### PR TITLE
Remove unidecode from dependencies

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 2
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   entry_points:
     - slugify=slugify.__main__:main
@@ -24,7 +24,6 @@ requirements:
   run:
     - python >=3.7
     - text-unidecode >=1.3
-    - unidecode >=1.1.1
   run_constrained:
     # ships slugify in site-packages and bin
     - slugify <0


### PR DESCRIPTION
python-slugify has unidecode as an optional dependency. unidecode has a GPL license. Including this in the dependencies in the feedstock means that all packages linked have to be GPL compatible.
Therefore care has been taken in python-slugify to make the install of unidecode completely optional. For 99% of users text-unidecode offers all functionality.

I removed unidecode from the dependencies in meta.yaml. Users who insist to use it can just install it by themselves. python-slugify checks the existence at runtime:

https://github.com/un33k/python-slugify/blob/cab324665b19ab661421697da79ebc902e0ea57c/slugify/slugify.py#L6-L11

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
